### PR TITLE
Fix lowercase bug in Config clean_text

### DIFF
--- a/config/Config.py
+++ b/config/Config.py
@@ -32,7 +32,7 @@ class Config(object):
             return 'Is not in the config file'
         return self.config[property_name]
 
-    def clean_text(cls, phrases):
+    def clean_text(self, phrases):
         regex_string = [
             {r'>\s+': u'>'},  # remove spaces after a tag opens or closes
             {r'\s+': u' '},  # replace consecutive spaces
@@ -87,7 +87,7 @@ class Config(object):
         phrases = phrases.replace("&nbsp;", " ")
         phrases = phrases.replace("\\", " ")
         phrases = phrases.replace("/", " ")
-        phrases.lower()
+        phrases = phrases.lower()
         phrases = ''.join([i for i in phrases if not i.isdigit()])
         return phrases
 


### PR DESCRIPTION
## Summary
- ensure text normalization function actually converts input to lowercase

## Testing
- `python3 -m py_compile config/Config.py`
- `python3 -m py_compile text_generator_mcb.py save_mcb_model.py bert_score.py`

------
https://chatgpt.com/codex/tasks/task_e_6840131acdbc8328ba7adbb6de30d836